### PR TITLE
Avoid encoding the last and first names when showing the values in the modal lookup

### DIFF
--- a/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Mirage2/scripts/hal.js
+++ b/dspace/modules/xmlui-mirage2/src/main/webapp/themes/Mirage2/scripts/hal.js
@@ -145,8 +145,8 @@
             }
 
 
-            var lastName = encodeURIComponent($lastName.val());
-            var firstName = encodeURIComponent($firstName.val());
+            var lastName = $lastName.val();
+            var firstName = $firstName.val();
 
 
             $('div#structure_name_lookup_no_results_authorentered-' + lookupField).addClass('hidden');


### PR DESCRIPTION
If you use the Manage affiliations popup on an author with diacritics, that diacriticis gets corrupted (e.g. Merkel, Sébastien--> Merkel, S%C3%A9bastien)
This encoding should NOT be applied in this part of the code